### PR TITLE
Revert workaround for older puppet-lint behavior

### DIFF
--- a/lib/puppet-lint/plugins/legacy_facts.rb
+++ b/lib/puppet-lint/plugins/legacy_facts.rb
@@ -124,9 +124,6 @@ PuppetLint.new_check(:legacy_facts) do
   end
 
   def fix(problem)
-    # This probably should never occur, but if it does then bail out:
-    raise PuppetLint::NoFix if problem[:token].raw and problem[:token].value != problem[:token].raw
-
     # Get rid of the top scope before we do our work. We don't need to
     # preserve it because it won't work with the new structured facts.
     if problem[:token].value.start_with?('::') then
@@ -157,7 +154,5 @@ PuppetLint.new_check(:legacy_facts) do
         problem[:token].value = "facts['solaris_zones']['zones']['" << m['name'] << "']['" << m['attribute'] << "']"
       end
     end
-
-    problem[:token].raw = problem[:token].value unless problem[:token].raw.nil?
   end
 end

--- a/puppet-lint-legacy_facts-check.gemspec
+++ b/puppet-lint-legacy_facts-check.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   `$facts['os']['name']` instead
   EOF
 
-  spec.add_dependency             'puppet-lint', '2.3.6'
+  spec.add_dependency             'puppet-lint', '~> 2.4'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec-its', '~> 1.0'
   spec.add_development_dependency 'rspec-json_expectations'


### PR DESCRIPTION
Versions of puppet-lint prior to 2.4 didn't handle parsing
complex variables in quoted strings well. As of 2.4.0 this
behavior has been completely rewritten and now seems to behave
as expected. This work around no longer seems to be needed.